### PR TITLE
Fix README.md missing code block syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,5 +148,7 @@ CIS Compliance checks |   |   | X
 If you come across any problems or would like to give us feedback on MicroScanner we encourage you to raise issues here on GitHub.
 
 ## Binary hash
+```sh
 $ md5 microscanner
 MD5 (microscanner) = d037e1c52d951093eaaf3f9138344e48
+```


### PR DESCRIPTION
The original rendering looks wrong.